### PR TITLE
Fix automatic build selection saving

### DIFF
--- a/api/routes/builds.py
+++ b/api/routes/builds.py
@@ -626,6 +626,7 @@ async def save_build_selection(selection_data: dict):
         if not isinstance(selected_builds, list):
             raise HTTPException(status_code=400, detail="selectedBuilds doit être une liste")
         
+        # Récupérer les builds TeamCity; si vide, le modèle créera un fallback pour ne pas perdre la sélection
         all_builds = await get_teamcity_builds_direct()
         success = user_service.bulk_update_selections(selected_builds, all_builds)
         


### PR DESCRIPTION
Fixes selected build persistence across pages by improving frontend loading and adding robust backend fallbacks.

The previous implementation could lose user selections due to the frontend overwriting the `selectedBuilds` array with an empty list from the build tree API, or the backend failing to save selections if the full TeamCity build list was unavailable. This PR ensures selections are robustly loaded from `/api/config` (with `localStorage` fallback) and saved even when TeamCity data is absent.

---
<a href="https://cursor.com/background-agent?bcId=bc-8de7519f-dcb3-4094-a49b-54ec9b8f9bb1">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-8de7519f-dcb3-4094-a49b-54ec9b8f9bb1">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

